### PR TITLE
Revisionierung auf Craft CMS umgestellt

### DIFF
--- a/.ddev/nginx/nginx-craftcms.conf
+++ b/.ddev/nginx/nginx-craftcms.conf
@@ -1,0 +1,5 @@
+# Nginx filename based cache busting: Versionierung durch Versionsnummer
+# https://nystudio107.com/blog/simple-static-asset-versioning
+location ~* (.+)\.(?:\d+)\.(js|css|png|jpg|jpeg|gif|webp)$ {
+    try_files $uri $1.$2;
+}

--- a/config/custom.php
+++ b/config/custom.php
@@ -1,0 +1,27 @@
+<!-- https://craftcms.com/docs/4.x/config/#custom-settings -->
+<!-- https://nystudio107.com/blog/simple-static-asset-versioning -->
+<?php
+    return array(
+
+        // All environments
+        '*' => array(
+            
+        ),
+        
+        // production environment
+        'production'  => array(
+            'staticAssetsVersion' => 1672330123,
+        ),
+
+        // Staging environment
+        'staging'  => array(
+            'staticAssetsVersion' => time(),
+        ),
+
+        // development environment
+        'dev'  => array(
+            'staticAssetsVersion' => time(),
+        ),
+    );
+
+;

--- a/config/general.php
+++ b/config/general.php
@@ -30,6 +30,9 @@ return GeneralConfig::create()
     // Disallow robots
     ->disallowRobots(!$isProduction)
 
+    // Allow template chaching
+    ->enableTemplateCaching(!$isDev)
+
     // Slugs ohne Umlaute
     ->limitAutoSlugsToAscii(true)
     // Loginadresse des Redaktionssystems

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
         "browser-sync": "^2.27.10",
         "cssnano": "^5.1.12",
         "dev-layouttools": "github:profitlich-ch/dev-layouttools",
+        "fancy-log": "^2.0.0",
         "gulp": "^4.0.2",
         "gulp-babel": "^8.0.0",
         "gulp-clean-css": "^4.3.0",

--- a/src/templates/_layout.twig
+++ b/src/templates/_layout.twig
@@ -11,22 +11,20 @@
 		</title>
 		<meta content="width=device-width, initial-scale=1.0" name="viewport">
 		{% block metaDescription %}{% endblock %}
-        {% js "/js/defer.js" with {
-            defer: true
-        } %}
+
+        {% set staticAssetsVersion = craft.app.config.custom.staticAssetsVersion %}
+
 		
 		<!-- https://web.dev/defer-non-critical-css/ -->
-		<link rel="preload" href="/css/style.css" as="style">
-		<link rel="stylesheet" href="/css/style.css" media="print" onload="this.media='all'">
-		<noscript><link rel="stylesheet" href="/css/style.css"/></noscript>
+		<link rel="preload" href="/css/style.{{ staticAssetsVersion }}.css" as="style">
+		<link rel="stylesheet" href="/css/style.{{ staticAssetsVersion }}.css" media="print" onload="this.media='all'">
+		<noscript><link rel="stylesheet" href="/css/style.{{ staticAssetsVersion }}.css"/></noscript>
 
         {% if devMode %}
-            <link rel="stylesheet" href="/css/dev.css">
-            {% js "/js/defer.js" with {
-                defer: true
-            } %}
+            <link rel="stylesheet" href="/css/dev.{{ staticAssetsVersion }}.css">
         {% endif %}
 
+        <script src="js/defer.{{ staticAssetsVersion }}.js" defer></script>
 		<script>
 			{{ source("/js/inline.js") }}
 		</script>

--- a/web/.htaccess
+++ b/web/.htaccess
@@ -7,3 +7,9 @@
     RewriteCond %{REQUEST_URI} !^/(favicon\.ico|apple-touch-icon.*\.png)$ [NC]
     RewriteRule (.+) index.php?p=$1 [QSA,L]
 </IfModule>
+
+<IfModule mod_rewrite.c>
+    RewriteEngine On
+    RewriteCond %{REQUEST_FILENAME} !-f
+    RewriteRule ^(.*?\/)*?([a-z\.\-]+)(\d+)\.(bmp|css|cur|gif|ico|jpe?g|js|png|svgz?|webp|webmanifest)$ $1$2$4 [L]
+</IfModule>


### PR DESCRIPTION
Revisionierung in Gulp gelöscht und auf Versionierung per Craft umgestellt. Dafür ein nginx snippet angelegt. Gulp aktualisiert nur noch die Versionsnummer in der general.php.

close